### PR TITLE
Add support for 4b quant mobilenet v1

### DIFF
--- a/trainablePreprocessing_examples/imagenet_classification/README.md
+++ b/trainablePreprocessing_examples/imagenet_classification/README.md
@@ -6,6 +6,7 @@ This implements training of popular model architectures, such as ResNet, AlexNet
 
 * PyTorch (last tested with v1.4.0)
 * Torchvision (last tested with v0.5.0)
+* Brevitas (branch quant_mobilenet_v1_4b-r2 to access latest MobileNet V1 release)
 
 ## Training
 

--- a/trainablePreprocessing_examples/imagenet_classification/main.py
+++ b/trainablePreprocessing_examples/imagenet_classification/main.py
@@ -92,6 +92,8 @@ parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                     help='evaluate model on validation set')
 parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                     help='use pre-trained model')
+parser.add_argument('--retrain', dest='retrain', action='store_true',
+                    help='Retrain resumed model')
 parser.add_argument('--seed', default=123456, type=int,
                     help='seed for initializing training. ')
 parser.add_argument('--gpu', default=None, type=int,
@@ -166,15 +168,16 @@ def main_worker(gpu, ngpus_per_node, args):
                 # Map model to be loaded to specified single gpu.
                 loc = 'cuda:{}'.format(args.gpu)
                 checkpoint = torch.load(args.resume, map_location=loc)
-            args.start_epoch = checkpoint['epoch']
-            best_acc1 = checkpoint['best_acc1']
-            if args.gpu is not None:
-                # best_acc1 may be from a checkpoint from a different GPU
-                best_acc1 = best_acc1.to(args.gpu)
             model.load_state_dict(checkpoint['state_dict'])
-            optimizer.load_state_dict(checkpoint['optimizer'])
-            print("=> loaded checkpoint '{}' (epoch {})"
-                  .format(args.resume, checkpoint['epoch']))
+            if not args.retrain:
+                optimizer.load_state_dict(checkpoint['optimizer'])
+                args.start_epoch = checkpoint['epoch']
+                best_acc1 = checkpoint['best_acc1']
+                if args.gpu is not None:
+                    # best_acc1 may be from a checkpoint from a different GPU
+                    best_acc1 = best_acc1.to(args.gpu)
+                print("=> loaded checkpoint '{}' (epoch {})"
+                    .format(args.resume, checkpoint['epoch']))
         else:
             print("=> no checkpoint found at '{}'".format(args.resume))
 

--- a/trainablePreprocessing_examples/imagenet_classification/main.py
+++ b/trainablePreprocessing_examples/imagenet_classification/main.py
@@ -88,6 +88,8 @@ parser.add_argument('-p', '--print-freq', default=10, type=int,
                     metavar='N', help='print frequency (default: 10)')
 parser.add_argument('--resume', default='', type=str, metavar='PATH',
                     help='path to latest checkpoint (default: none)')
+parser.add_argument('--resume-strict', action='store_true', default=False,
+                    help='Strict state dict loading during resuming')
 parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                     help='evaluate model on validation set')
 parser.add_argument('--pretrained', dest='pretrained', action='store_true',
@@ -168,7 +170,7 @@ def main_worker(gpu, ngpus_per_node, args):
                 # Map model to be loaded to specified single gpu.
                 loc = 'cuda:{}'.format(args.gpu)
                 checkpoint = torch.load(args.resume, map_location=loc)
-            model.load_state_dict(checkpoint['state_dict'])
+            model.load_state_dict(checkpoint['state_dict'], strict=args.resume_strict)
             if not args.retrain:
                 optimizer.load_state_dict(checkpoint['optimizer'])
                 args.start_epoch = checkpoint['epoch']

--- a/trainablePreprocessing_examples/imagenet_classification/main.py
+++ b/trainablePreprocessing_examples/imagenet_classification/main.py
@@ -78,6 +78,7 @@ parser.add_argument('-b', '--batch-size', default=256, type=int,
                          'using Data Parallel or Distributed Data Parallel')
 parser.add_argument('--lr', '--learning-rate', default=0.1, type=float,
                     metavar='LR', help='initial learning rate', dest='lr')
+parser.add_argument('--lr_decay_interval', default=30, type=int, help='learning rate decay interval')
 parser.add_argument('--momentum', default=0.9, type=float, metavar='M',
                     help='momentum')
 parser.add_argument('--wd', '--weight-decay', default=1e-4, type=float,
@@ -91,7 +92,7 @@ parser.add_argument('-e', '--evaluate', dest='evaluate', action='store_true',
                     help='evaluate model on validation set')
 parser.add_argument('--pretrained', dest='pretrained', action='store_true',
                     help='use pre-trained model')
-parser.add_argument('--seed', default=None, type=int,
+parser.add_argument('--seed', default=123456, type=int,
                     help='seed for initializing training. ')
 parser.add_argument('--gpu', default=None, type=int,
                     help='GPU id to use.')
@@ -124,8 +125,11 @@ def main_worker(gpu, ngpus_per_node, args):
 
     # create model
     if args.preproc_mode is not None:
-        model = preproc_models.__dict__[args.arch](preproc_mode=args.preproc_mode, colortrans=args.colortrans,
-                                                input_bit_width=args.input_bit_width)
+        model = preproc_models.__dict__[args.arch](
+            preproc_mode=args.preproc_mode,
+            colortrans=args.colortrans,
+            input_bit_width=args.input_bit_width,
+            pretrained=args.pretrained)
     else:
         if args.pretrained:
             print("=> using pre-trained model '{}'".format(args.arch))
@@ -179,8 +183,6 @@ def main_worker(gpu, ngpus_per_node, args):
     # Data loading code
     traindir = os.path.join(args.data, 'train')
     valdir = os.path.join(args.data, 'val')
-    normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                     std=[0.229, 0.224, 0.225])
 
     train_dataset = datasets.ImageFolder(
         traindir,
@@ -188,7 +190,6 @@ def main_worker(gpu, ngpus_per_node, args):
             transforms.RandomResizedCrop(224),
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
-            #normalize,
         ]))
 
     train_loader = torch.utils.data.DataLoader(
@@ -200,7 +201,6 @@ def main_worker(gpu, ngpus_per_node, args):
             transforms.Resize(256),
             transforms.CenterCrop(224),
             transforms.ToTensor(),
-            #normalize,
         ])),
         batch_size=args.batch_size, shuffle=False,
         num_workers=args.workers, pin_memory=True)
@@ -210,7 +210,7 @@ def main_worker(gpu, ngpus_per_node, args):
         return
 
     for epoch in range(args.start_epoch, args.epochs):
-        adjust_learning_rate(optimizer, epoch, args)
+        adjust_learning_rate(optimizer, epoch, args.lr, args.lr_decay_interval)
 
         # train for one epoch
         train(train_loader, model, criterion, optimizer, epoch, args)
@@ -367,9 +367,9 @@ class ProgressMeter(object):
         return '[' + fmt + '/' + fmt.format(num_batches) + ']'
 
 
-def adjust_learning_rate(optimizer, epoch, args):
+def adjust_learning_rate(optimizer, epoch, starting_lr, decay_interval):
     """Sets the learning rate to the initial LR decayed by 10 every 30 epochs"""
-    lr = args.lr * (0.1 ** (epoch // 30))
+    lr = starting_lr * (0.1 ** (epoch // decay_interval))
     for param_group in optimizer.param_groups:
         param_group['lr'] = lr
 

--- a/trainablePreprocessing_examples/imagenet_classification/preproc_models/__init__.py
+++ b/trainablePreprocessing_examples/imagenet_classification/preproc_models/__init__.py
@@ -1,1 +1,2 @@
 from .preproc_resnet import *
+from .preproc_quant_mobilenetv1 import *

--- a/trainablePreprocessing_examples/imagenet_classification/preproc_models/preproc_quant_mobilenetv1.py
+++ b/trainablePreprocessing_examples/imagenet_classification/preproc_models/preproc_quant_mobilenetv1.py
@@ -1,0 +1,109 @@
+#   Copyright (c) 2020, Xilinx, Inc.
+#   All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions are met:
+#
+#   1.  Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#   2.  Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#   3.  Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived from
+#       this software without specific prior written permission.
+#
+#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#   PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+#   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+#   OR BUSINESS INTERRUPTION). HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+#   OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#   ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import torch
+from torch.nn import ModuleList, Module
+from brevitas_examples.imagenet_classification import model_with_cfg
+from brevitas_examples.imagenet_classification.models.mobilenetv1 import MobileNet
+
+from trainablePreprocessing.preprocessing import TrainedDithering, FixedDithering
+from trainablePreprocessing.preprocessing import Quantization, ColorSpaceTransformation
+
+
+class Normalize(Module):
+    def __init__(self, mean, std, channels):
+        super(Normalize, self).__init__()
+        self.mean = mean
+        self.std = std
+        self.channels = channels
+
+    def forward(self, x):
+        channels = self.channels
+        x = x - torch.tensor(self.mean, device=x.device).reshape(1, channels, 1, 1)
+        x = x / torch.tensor(self.std, device=x.device).reshape(1, channels, 1, 1)
+        return x
+
+
+class PreprocMobileNetV1(MobileNet):
+
+    def __init__(
+            self,
+            bit_width,
+            channels,
+            first_layer_bit_width,
+            first_stage_stride,
+            input_norm_mean,
+            input_norm_std,
+            input_channels,
+            preproc_mode='quant', colortrans=False, input_bit_width=8):
+        super(PreprocMobileNetV1, self).__init__(
+            channels,
+            first_stage_stride,
+            first_layer_bit_width,
+            bit_width)
+        self.preproc_features = ModuleList()
+        if colortrans:
+            self.preproc_features.append(ColorSpaceTransformation(3, 3))
+        if preproc_mode == 'trained_dithering':
+            self.preproc_features.append(TrainedDithering(input_bit_width, 3, 3))
+        elif preproc_mode == 'fixed_dithering':
+            self.preproc_features.append(FixedDithering(input_bit_width, 3))
+        elif preproc_mode == 'quant':
+            self.preproc_features.append(Quantization(input_bit_width))
+        self.preproc_features.append(Normalize(input_norm_mean, input_norm_std, input_channels))
+
+    def forward(self, x):
+        for mod in self.preproc_features:
+            x = mod(x)
+        x = super(PreprocMobileNetV1, self).forward(x)
+        return x
+
+
+def preproc_mobilenet_v1(pretrained=True, **kwargs):
+    first_stage_stride = False
+    channels = [[32], [64], [128, 128], [256, 256], [512, 512, 512, 512, 512, 512], [1024, 1024]]
+    orig_quant_mobilenet_v1_4b, cfg = model_with_cfg('quant_mobilenet_v1_4b', pretrained=pretrained)
+    bit_width = cfg.getint('QUANT', 'BIT_WIDTH')
+    first_layer_bit_width = cfg.getint('QUANT', 'FIRST_LAYER_BIT_WIDTH')
+    width_scale = float(cfg.get('MODEL', 'WIDTH_SCALE'))
+    input_channels = 3
+    mean = [float(cfg.get('PREPROCESS', 'MEAN_0')),
+            float(cfg.get('PREPROCESS', 'MEAN_1')),
+            float(cfg.get('PREPROCESS', 'MEAN_2'))]
+    std = [float(cfg.get('PREPROCESS', 'STD_0')),
+           float(cfg.get('PREPROCESS', 'STD_1')),
+           float(cfg.get('PREPROCESS', 'STD_2'))]
+    if width_scale != 1.0:
+        channels = [[int(cij * width_scale) for cij in ci] for ci in channels]
+    net = PreprocMobileNetV1(
+        bit_width, channels, first_layer_bit_width, first_stage_stride, mean, std, input_channels, **kwargs)
+    if pretrained:
+        orig_state_dict = orig_quant_mobilenet_v1_4b.state_dict()
+        net.load_state_dict(orig_state_dict, strict=False)
+    return net

--- a/trainablePreprocessing_examples/imagenet_classification/preproc_models/preproc_resnet.py
+++ b/trainablePreprocessing_examples/imagenet_classification/preproc_models/preproc_resnet.py
@@ -61,36 +61,48 @@ def preproc_resnet18(**kwargs):
     r"""ResNet-18 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
     """
+    assert(not kwargs['pretrained']), 'Not supported'
+    del kwargs['pretrained']
     return PreprocResNet(resnet.BasicBlock, [2, 2, 2, 2], **kwargs)
 
 
 def preproc_resnet34(**kwargs):
     r"""ResNet-34 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     return PreprocResNet(resnet.BasicBlock, [3, 4, 6, 3], **kwargs)
 
 
 def preproc_resnet50(**kwargs):
     r"""ResNet-50 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     return PreprocResNet(resnet.Bottleneck, [3, 4, 6, 3], **kwargs)
 
 
 def preproc_resnet101(**kwargs):
     r"""ResNet-101 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     return PreprocResNet(resnet.Bottleneck, [3, 4, 23, 3], **kwargs)
 
 
 def preproc_resnet152(**kwargs):
     r"""ResNet-152 model from
     `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     return PreprocResNet(resnet.Bottleneck, [3, 8, 36, 3], **kwargs)
 
 
 def preproc_resnext50_32x4d(**kwargs):
     r"""ResNeXt-50 32x4d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 4
     return PreprocResNet(resnet.Bottleneck, [3, 4, 6, 3], **kwargs)
@@ -99,6 +111,8 @@ def preproc_resnext50_32x4d(**kwargs):
 def preproc_resnext101_32x8d(**kwargs):
     r"""ResNeXt-101 32x8d model from
     `"Aggregated Residual Transformation for Deep Neural Networks" <https://arxiv.org/pdf/1611.05431.pdf>`_"""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     kwargs['groups'] = 32
     kwargs['width_per_group'] = 8
     return PreprocResNet(resnet.Bottleneck, [3, 4, 23, 3], **kwargs)
@@ -112,6 +126,8 @@ def preproc_wide_resnet50_2(**kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048."""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     kwargs['width_per_group'] = 64 * 2
     return PreprocResNet(resnet.Bottleneck, [3, 4, 6, 3], **kwargs)
 
@@ -124,5 +140,7 @@ def preproc_wide_resnet101_2(**kwargs):
     which is twice larger in every block. The number of channels in outer 1x1
     convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
     channels, and in Wide ResNet-50-2 has 2048-1024-2048."""
+    assert not kwargs['pretrained'], 'Not supported'
+    del kwargs['pretrained']
     kwargs['width_per_group'] = 64 * 2
     return PreprocResNet(resnet.Bottleneck, [3, 4, 23, 3], **kwargs)


### PR DESCRIPTION
Add support for pretrained 4b quantized MobileNet V1 imported from Brevitas. 
Additionally, I set a default seed, remove the unused preprocessing coefficients, and moved the lr scheduler decay interval parameter to the arg parser.